### PR TITLE
feat: HomogeneityAnalyzer and ReturnsToScale (#14)

### DIFF
--- a/econ_viz/analysis/__init__.py
+++ b/econ_viz/analysis/__init__.py
@@ -1,0 +1,13 @@
+"""
+econ_viz.analysis — Analytical tools for utility and demand theory.
+
+Submodules
+----------
+homogeneity
+    Homogeneity degree detection, Euler's theorem verification,
+    homotheticity testing, and demand degree-0 verification.
+"""
+
+from .homogeneity import HomogeneityAnalyzer, HomogeneityResult
+
+__all__ = ["HomogeneityAnalyzer", "HomogeneityResult"]

--- a/econ_viz/analysis/homogeneity.py
+++ b/econ_viz/analysis/homogeneity.py
@@ -1,0 +1,236 @@
+"""
+Homogeneity analysis for utility and production functions.
+
+Provides :class:`HomogeneityAnalyzer`, which numerically tests whether a
+callable ``f(x, y)`` satisfies homogeneity of degree *k*, verifies Euler's
+theorem, checks homotheticity, and confirms that Marshallian demands are
+homogeneous of degree 0 in prices and income.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..enums import ReturnsToScale
+
+
+@dataclass(frozen=True)
+class HomogeneityResult:
+    """Summary of a homogeneity analysis.
+
+    Attributes
+    ----------
+    degree : float or None
+        Estimated homogeneity degree *k*, or ``None`` if no consistent
+        degree was found across sampled bundles.
+    is_homogeneous : bool
+        ``True`` when *degree* is not ``None``.
+    returns_to_scale : ReturnsToScale
+        Scaling classification derived from *degree*.
+    """
+
+    degree: float | None
+    is_homogeneous: bool
+    returns_to_scale: ReturnsToScale
+
+
+class HomogeneityAnalyzer:
+    """Numerical homogeneity analyser for a two-good utility function.
+
+    Parameters
+    ----------
+    func : callable
+        A utility model ``f(x, y)`` accepting scalar floats and returning
+        a scalar float.  Any object satisfying the ``UtilityFunction``
+        protocol is accepted.
+    tol : float
+        Tolerance for degree consistency and Euler residual checks.
+    n_samples : int
+        Number of base bundles sampled when estimating the degree.
+    """
+
+    def __init__(self, func, *, tol: float = 1e-4, n_samples: int = 8) -> None:
+        self._func = func
+        self._tol = tol
+        self._n_samples = n_samples
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def degree(self) -> HomogeneityResult:
+        """Estimate the homogeneity degree *k*.
+
+        Samples *n_samples* base bundles $(x_0, y_0)$ drawn from a
+        log-uniform grid on $[0.5, 5]^2$ and three scaling factors
+        $\\lambda \\in \\{0.5, 2.0, 4.0\\}$.  For each combination:
+
+        .. math::
+
+            k = \\frac{\\ln f(\\lambda x_0,\\, \\lambda y_0) - \\ln f(x_0, y_0)}{\\ln \\lambda}
+
+        Returns ``None`` in the result when the estimated *k* values are
+        inconsistent (standard deviation > *tol*).
+
+        Returns
+        -------
+        HomogeneityResult
+        """
+        rng = np.random.default_rng(0)
+        xs = np.exp(rng.uniform(np.log(0.5), np.log(5.0), self._n_samples))
+        ys = np.exp(rng.uniform(np.log(0.5), np.log(5.0), self._n_samples))
+        lambdas = [0.5, 2.0, 4.0]
+
+        estimates: list[float] = []
+        for x0, y0 in zip(xs, ys):
+            f0 = float(self._func(x0, y0))
+            if f0 <= 0:
+                continue
+            for lam in lambdas:
+                fl = float(self._func(lam * x0, lam * y0))
+                if fl <= 0:
+                    continue
+                estimates.append((np.log(fl) - np.log(f0)) / np.log(lam))
+
+        if not estimates:
+            return HomogeneityResult(
+                degree=None,
+                is_homogeneous=False,
+                returns_to_scale=ReturnsToScale.NOT_HOMOGENEOUS,
+            )
+
+        arr = np.array(estimates)
+        arr = arr[np.isfinite(arr)]
+        if len(arr) < 3 or arr.std() > self._tol:
+            return HomogeneityResult(
+                degree=None,
+                is_homogeneous=False,
+                returns_to_scale=ReturnsToScale.NOT_HOMOGENEOUS,
+            )
+
+        k = float(arr.mean())
+        return HomogeneityResult(
+            degree=k,
+            is_homogeneous=True,
+            returns_to_scale=ReturnsToScale.from_degree(k, tol=self._tol),
+        )
+
+    def euler_check(self, x: float, y: float) -> float:
+        """Return the relative Euler residual at bundle *(x, y)*.
+
+        For a degree-*k* homogeneous function the residual should be
+        near zero:
+
+        .. math::
+
+            \\varepsilon = \\frac{\\left| x \\partial_x f + y \\partial_y f
+                           - k \\cdot f(x, y) \\right|}{|f(x, y)|}
+
+        Parameters
+        ----------
+        x, y : float
+            Bundle coordinates (must be strictly positive).
+
+        Returns
+        -------
+        float
+            Relative residual.  Values below *tol* indicate the theorem
+            holds numerically.
+        """
+        result = self.degree()
+        if not result.is_homogeneous or result.degree is None:
+            return float("nan")
+
+        k = result.degree
+        h = 1e-5
+        df_dx = (float(self._func(x + h, y)) - float(self._func(x - h, y))) / (2 * h)
+        df_dy = (float(self._func(x, y + h)) - float(self._func(x, y - h))) / (2 * h)
+        fxy = float(self._func(x, y))
+
+        lhs = x * df_dx + y * df_dy
+        return abs(lhs - k * fxy) / abs(fxy)
+
+    def is_homothetic(self, *, n_samples: int = 6) -> bool:
+        """Test whether the function is homothetic.
+
+        A function is homothetic if the MRS depends only on the ratio
+        $x / y$, not on the scale of the bundle:
+
+        .. math::
+
+            \\text{MRS}(x_0, y_0) \\approx \\text{MRS}(\\lambda x_0,\\, \\lambda y_0)
+
+        Samples *n_samples* base bundles and tests with
+        $\\lambda \\in \\{0.5, 2.0, 4.0\\}$.
+
+        Returns
+        -------
+        bool
+        """
+        rng = np.random.default_rng(1)
+        xs = np.exp(rng.uniform(np.log(0.5), np.log(4.0), n_samples))
+        ys = np.exp(rng.uniform(np.log(0.5), np.log(4.0), n_samples))
+        lambdas = [0.5, 2.0, 4.0]
+        h = 1e-5
+
+        def _mrs(x, y) -> float:
+            df_dx = (float(self._func(x + h, y)) - float(self._func(x - h, y))) / (2 * h)
+            df_dy = (float(self._func(x, y + h)) - float(self._func(x, y - h))) / (2 * h)
+            if abs(df_dy) < 1e-12:
+                return float("nan")
+            return df_dx / df_dy
+
+        for x0, y0 in zip(xs, ys):
+            mrs0 = _mrs(x0, y0)
+            if np.isnan(mrs0):
+                continue
+            for lam in lambdas:
+                mrs_scaled = _mrs(lam * x0, lam * y0)
+                if np.isnan(mrs_scaled):
+                    continue
+                if abs(mrs_scaled - mrs0) > self._tol * (1 + abs(mrs0)):
+                    return False
+        return True
+
+    def demand_degree_zero(
+        self,
+        px: float,
+        py: float,
+        income: float,
+        *,
+        scales: tuple[float, ...] = (0.5, 2.0, 5.0),
+    ) -> bool:
+        """Verify Marshallian demands are homogeneous of degree 0 in $(p_x, p_y, I)$.
+
+        Checks that scaling all prices and income by $t$ leaves the
+        optimal bundle unchanged:
+
+        .. math::
+
+            x^{*}(t p_x,\\, t p_y,\\, t I) = x^{*}(p_x, p_y, I)
+
+        Parameters
+        ----------
+        px, py : float
+            Reference prices (must be positive).
+        income : float
+            Reference income (must be positive).
+        scales : tuple of float
+            Scale factors $t$ to test.
+
+        Returns
+        -------
+        bool
+        """
+        from ..optimizer import solve
+
+        eq0 = solve(self._func, px=px, py=py, income=income)
+        for t in scales:
+            eq_t = solve(self._func, px=t * px, py=t * py, income=t * income)
+            if abs(eq_t.x - eq0.x) > self._tol * (1 + abs(eq0.x)):
+                return False
+            if abs(eq_t.y - eq0.y) > self._tol * (1 + abs(eq0.y)):
+                return False
+        return True

--- a/econ_viz/enums/__init__.py
+++ b/econ_viz/enums/__init__.py
@@ -9,5 +9,6 @@ validate export formats at save time.
 
 from .utility import UtilityType
 from .extension import ExportFormat
+from .returns import ReturnsToScale
 
-__all__ = ["UtilityType", "ExportFormat"]
+__all__ = ["UtilityType", "ExportFormat", "ReturnsToScale"]

--- a/econ_viz/enums/returns.py
+++ b/econ_viz/enums/returns.py
@@ -1,0 +1,53 @@
+"""
+Enumeration of returns-to-scale classifications.
+
+Derived from the homogeneity degree *k* of a utility or production function
+and used by :class:`~econ_viz.analysis.homogeneity.HomogeneityAnalyzer` to
+summarise scaling behaviour in production-theoretic terms.
+"""
+
+from enum import Enum, auto
+
+
+class ReturnsToScale(Enum):
+    """Returns-to-scale classification derived from homogeneity degree.
+
+    Members
+    -------
+    INCREASING
+        Degree *k* > 1: doubling inputs more than doubles output.
+    CONSTANT
+        Degree *k* = 1: doubling inputs exactly doubles output.
+    DECREASING
+        0 < *k* < 1: doubling inputs less than doubles output.
+    NOT_HOMOGENEOUS
+        No consistent degree *k* exists across sampled bundles.
+    """
+
+    INCREASING = auto()
+    CONSTANT = auto()
+    DECREASING = auto()
+    NOT_HOMOGENEOUS = auto()
+
+    @classmethod
+    def from_degree(cls, k: float | None, tol: float = 1e-4) -> "ReturnsToScale":
+        """Classify a homogeneity degree into a returns-to-scale member.
+
+        Parameters
+        ----------
+        k : float or None
+            Estimated homogeneity degree, or ``None`` if not homogeneous.
+        tol : float
+            Tolerance for treating *k* as exactly 1 (constant returns).
+
+        Returns
+        -------
+        ReturnsToScale
+        """
+        if k is None:
+            return cls.NOT_HOMOGENEOUS
+        if abs(k - 1.0) <= tol:
+            return cls.CONSTANT
+        if k > 1.0:
+            return cls.INCREASING
+        return cls.DECREASING

--- a/tests/test_homogeneity.py
+++ b/tests/test_homogeneity.py
@@ -1,0 +1,190 @@
+"""Tests for econ_viz.analysis.homogeneity — HomogeneityAnalyzer."""
+
+import math
+import pytest
+import numpy as np
+
+from econ_viz.analysis import HomogeneityAnalyzer, HomogeneityResult
+from econ_viz.enums import ReturnsToScale
+from econ_viz.models import CobbDouglas, Leontief, PerfectSubstitutes, CES, StoneGeary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _ShiftedCD:
+    """Stone-Geary-like shifted Cobb-Douglas — NOT homogeneous."""
+    def __call__(self, x, y):
+        return (x - 1) ** 0.5 * (y - 1) ** 0.5
+
+
+class _CRSProduction:
+    """f(x,y) = x^0.3 * y^0.7 — homogeneous of degree 1."""
+    def __call__(self, x, y):
+        return x ** 0.3 * y ** 0.7
+
+
+class _IRS:
+    """f(x,y) = x^0.8 * y^0.8 — homogeneous of degree 1.6."""
+    def __call__(self, x, y):
+        return x ** 0.8 * y ** 0.8
+
+
+class _DRS:
+    """f(x,y) = x^0.2 * y^0.3 — homogeneous of degree 0.5."""
+    def __call__(self, x, y):
+        return x ** 0.2 * y ** 0.3
+
+
+# ---------------------------------------------------------------------------
+# HomogeneityResult dataclass
+# ---------------------------------------------------------------------------
+
+class TestHomogeneityResult:
+    def test_frozen(self):
+        r = HomogeneityResult(degree=1.0, is_homogeneous=True,
+                              returns_to_scale=ReturnsToScale.CONSTANT)
+        with pytest.raises(Exception):
+            r.degree = 2.0
+
+
+# ---------------------------------------------------------------------------
+# ReturnsToScale.from_degree
+# ---------------------------------------------------------------------------
+
+class TestReturnsToScaleFromDegree:
+    def test_none_returns_not_homogeneous(self):
+        assert ReturnsToScale.from_degree(None) is ReturnsToScale.NOT_HOMOGENEOUS
+
+    def test_exactly_one(self):
+        assert ReturnsToScale.from_degree(1.0) is ReturnsToScale.CONSTANT
+
+    def test_within_tol_of_one(self):
+        assert ReturnsToScale.from_degree(1.0 + 5e-5) is ReturnsToScale.CONSTANT
+
+    def test_increasing(self):
+        assert ReturnsToScale.from_degree(1.5) is ReturnsToScale.INCREASING
+
+    def test_decreasing(self):
+        assert ReturnsToScale.from_degree(0.5) is ReturnsToScale.DECREASING
+
+
+# ---------------------------------------------------------------------------
+# HomogeneityAnalyzer.degree()
+# ---------------------------------------------------------------------------
+
+class TestDegree:
+    def test_cobb_douglas_degree(self):
+        cd = CobbDouglas(alpha=0.4, beta=0.6)
+        result = HomogeneityAnalyzer(cd).degree()
+        assert result.is_homogeneous
+        assert result.degree == pytest.approx(1.0, abs=1e-3)
+
+    def test_cobb_douglas_returns_to_scale(self):
+        cd = CobbDouglas(alpha=0.4, beta=0.6)
+        result = HomogeneityAnalyzer(cd).degree()
+        assert result.returns_to_scale is ReturnsToScale.CONSTANT
+
+    def test_irs_degree(self):
+        result = HomogeneityAnalyzer(_IRS()).degree()
+        assert result.is_homogeneous
+        assert result.degree == pytest.approx(1.6, abs=1e-3)
+        assert result.returns_to_scale is ReturnsToScale.INCREASING
+
+    def test_drs_degree(self):
+        result = HomogeneityAnalyzer(_DRS()).degree()
+        assert result.is_homogeneous
+        assert result.degree == pytest.approx(0.5, abs=1e-3)
+        assert result.returns_to_scale is ReturnsToScale.DECREASING
+
+    def test_leontief_degree_one(self):
+        result = HomogeneityAnalyzer(Leontief(a=1.0, b=1.0)).degree()
+        assert result.is_homogeneous
+        assert result.degree == pytest.approx(1.0, abs=1e-3)
+
+    def test_perfect_substitutes_degree_one(self):
+        result = HomogeneityAnalyzer(PerfectSubstitutes(a=1.0, b=1.0)).degree()
+        assert result.is_homogeneous
+        assert result.degree == pytest.approx(1.0, abs=1e-3)
+
+    def test_ces_degree_one(self):
+        result = HomogeneityAnalyzer(CES(alpha=0.5, beta=0.5, rho=0.5)).degree()
+        assert result.is_homogeneous
+        assert result.degree == pytest.approx(1.0, abs=1e-3)
+
+    def test_not_homogeneous(self):
+        result = HomogeneityAnalyzer(_ShiftedCD()).degree()
+        assert not result.is_homogeneous
+        assert result.degree is None
+        assert result.returns_to_scale is ReturnsToScale.NOT_HOMOGENEOUS
+
+    @pytest.mark.parametrize("alpha,beta", [(0.3, 0.7), (0.5, 0.5), (0.2, 0.8)])
+    def test_cobb_douglas_parametric(self, alpha, beta):
+        cd = CobbDouglas(alpha=alpha, beta=beta)
+        result = HomogeneityAnalyzer(cd).degree()
+        assert result.degree == pytest.approx(alpha + beta, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# HomogeneityAnalyzer.euler_check()
+# ---------------------------------------------------------------------------
+
+class TestEulerCheck:
+    def test_cobb_douglas_euler_near_zero(self):
+        cd = CobbDouglas(alpha=0.4, beta=0.6)
+        residual = HomogeneityAnalyzer(cd).euler_check(x=3.0, y=4.0)
+        assert residual == pytest.approx(0.0, abs=1e-4)
+
+    def test_euler_multiple_bundles(self):
+        az = HomogeneityAnalyzer(CobbDouglas(alpha=0.5, beta=0.5))
+        for x, y in [(1.0, 1.0), (2.0, 3.0), (5.0, 0.5)]:
+            assert az.euler_check(x, y) == pytest.approx(0.0, abs=1e-4)
+
+    def test_not_homogeneous_returns_nan(self):
+        az = HomogeneityAnalyzer(_ShiftedCD())
+        assert math.isnan(az.euler_check(x=2.0, y=2.0))
+
+
+# ---------------------------------------------------------------------------
+# HomogeneityAnalyzer.is_homothetic()
+# ---------------------------------------------------------------------------
+
+class TestIsHomothetic:
+    def test_cobb_douglas_is_homothetic(self):
+        assert HomogeneityAnalyzer(CobbDouglas()).is_homothetic()
+
+    def test_ces_is_homothetic(self):
+        assert HomogeneityAnalyzer(CES(0.5, 0.5, 0.5)).is_homothetic()
+
+    def test_leontief_is_homothetic(self):
+        assert HomogeneityAnalyzer(Leontief(1.0, 1.0)).is_homothetic()
+
+    def test_stone_geary_not_homothetic(self):
+        sg = StoneGeary(alpha=0.5, beta=0.5, bar_x=1.0, bar_y=1.0)
+        assert not HomogeneityAnalyzer(sg).is_homothetic()
+
+
+# ---------------------------------------------------------------------------
+# HomogeneityAnalyzer.demand_degree_zero()
+# ---------------------------------------------------------------------------
+
+class TestDemandDegreeZero:
+    def test_cobb_douglas(self):
+        cd = CobbDouglas(alpha=0.5, beta=0.5)
+        assert HomogeneityAnalyzer(cd).demand_degree_zero(px=2.0, py=3.0, income=60.0)
+
+    def test_leontief(self):
+        lf = Leontief(a=1.0, b=1.0)
+        assert HomogeneityAnalyzer(lf).demand_degree_zero(px=2.0, py=3.0, income=60.0)
+
+    def test_ces(self):
+        ces = CES(alpha=0.5, beta=0.5, rho=0.5)
+        assert HomogeneityAnalyzer(ces).demand_degree_zero(px=2.0, py=3.0, income=60.0)
+
+    @pytest.mark.parametrize("scale", [0.5, 2.0, 5.0, 10.0])
+    def test_scale_invariance(self, scale):
+        cd = CobbDouglas(alpha=0.4, beta=0.6)
+        assert HomogeneityAnalyzer(cd).demand_degree_zero(
+            px=2.0, py=3.0, income=60.0, scales=(scale,)
+        )


### PR DESCRIPTION
## Summary

- Adds `econ_viz/analysis/` submodule (future home for `statics.py` #12 and `slutsky.py` #13)
- Implements `HomogeneityAnalyzer` with four capabilities: degree detection, Euler's theorem check, homotheticity test, demand degree-0 verification
- Adds `ReturnsToScale` enum to `econ_viz/enums/`

## Test plan

- [x] 31 new tests in `tests/test_homogeneity.py`
- [x] Full suite: 266 passed, 0 failed
- [x] Coverage: 81% overall

Closes #14