### PR TITLE
feat: Translog model (#9) + legend/IC label support (#11)

### DIFF
--- a/econ_viz/canvas/base.py
+++ b/econ_viz/canvas/base.py
@@ -109,6 +109,7 @@ class Canvas:
         self.theme = theme
 
         self.fig, self.ax = plt.subplots(figsize=(6, 6))
+        self._legend_handles: list = []
         self._apply_base_style()
         logger.debug("Canvas created: x_max=%s, y_max=%s, dpi=%s, theme=%s",
                      x_max, y_max, self.dpi, theme.name)
@@ -186,6 +187,9 @@ class Canvas:
         show_kinks: bool = False,
         kink_radius: float = 1.0,
         show_bliss: bool = True,
+        label: str | None = None,
+        show_ic_labels: bool = False,
+        ic_label_fmt: str = "{:.2g}",
         **kwargs,
     ) -> Canvas:
         """Add indifference curves for a given utility function.
@@ -215,6 +219,14 @@ class Canvas:
             If ``True`` (default) and *func* has ``bliss_x`` / ``bliss_y``
             attributes (i.e. a :class:`~econ_viz.models.Satiation` model),
             draw a star marker at the bliss point.
+        label : str or None
+            Legend label for this indifference curve family.  Appears in the
+            legend when :meth:`show_legend` is called.
+        show_ic_labels : bool
+            If ``True``, place a small text label at the right end of each
+            indifference curve showing its utility level.
+        ic_label_fmt : str
+            Python format string for the level value (default ``"{:.2g}"``).
         **kwargs
             Forwarded to :meth:`matplotlib.axes.Axes.contour`.
 
@@ -234,8 +246,13 @@ class Canvas:
             show_kinks=show_kinks,
             kink_color=t.kink_color,
             kink_radius=kink_radius,
+            label=label,
+            show_ic_labels=show_ic_labels,
+            ic_label_fmt=ic_label_fmt,
         )
         ic.draw(self.ax, self.x_max, self.y_max, **kwargs)
+        if ic._proxy is not None:
+            self._legend_handles.append(ic._proxy)
         if show_bliss and hasattr(func, "bliss_x") and hasattr(func, "bliss_y"):
             c = color or t.ic_color
             self.ax.plot(
@@ -421,6 +438,33 @@ class Canvas:
                 textcoords="offset points", xytext=offset,
                 fontsize=12, color=c,
             )
+        return self
+
+    def show_legend(self, **kwargs) -> Canvas:
+        """Render a legend for all labelled layers.
+
+        Collects proxy artists registered by :meth:`add_utility`,
+        :meth:`add_budget` (when a *label* is supplied), and any future
+        labelled layers, then delegates to :meth:`matplotlib.axes.Axes.legend`.
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :meth:`matplotlib.axes.Axes.legend`.  Common options:
+            ``loc``, ``frameon``, ``fontsize``.
+
+        Returns
+        -------
+        Canvas
+            *self*, to allow method chaining.
+        """
+        budget_handles, budget_labels = self.ax.get_legend_handles_labels()
+        all_handles = self._legend_handles + budget_handles
+        if all_handles:
+            all_labels = [h.get_label() for h in self._legend_handles] + budget_labels
+            kwargs.setdefault("frameon", False)
+            kwargs.setdefault("fontsize", 11)
+            self.ax.legend(handles=all_handles, labels=all_labels, **kwargs)
         return self
 
     # ------------------------------------------------------------------

--- a/econ_viz/components/indifference.py
+++ b/econ_viz/components/indifference.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 from ..enums import UtilityType
 from ..logging import get_logger
 
@@ -43,6 +45,9 @@ class IndifferenceCurves:
         show_kinks: bool = False,
         kink_color: str = "black",
         kink_radius: float = 1.0,
+        label: str | None = None,
+        show_ic_labels: bool = False,
+        ic_label_fmt: str = "{:.2g}",
     ):
         self.func = func
         self.levels = levels
@@ -54,6 +59,9 @@ class IndifferenceCurves:
         self.show_kinks = show_kinks
         self.kink_color = kink_color
         self.kink_radius = kink_radius
+        self.label = label
+        self.show_ic_labels = show_ic_labels
+        self.ic_label_fmt = ic_label_fmt
 
     def draw(self, ax, x_max: float, y_max: float, **kwargs) -> list[float]:
         """Draw curves onto *ax* and return the computed contour levels."""
@@ -70,10 +78,39 @@ class IndifferenceCurves:
 
         logger.debug("Drawing contours at levels: %s", computed)
 
-        ax.contour(
+        cs = ax.contour(
             X, Y, Z, levels=computed,
             colors=self.color, linewidths=self.linewidth, **kwargs,
         )
+
+        if self.label is not None:
+            import matplotlib.lines as mlines
+            self._proxy = mlines.Line2D(
+                [], [], color=self.color, linewidth=self.linewidth, label=self.label
+            )
+        else:
+            self._proxy = None
+
+        if self.show_ic_labels:
+            for level, segs in zip(computed, cs.allsegs):
+                best_x, best_y = -1.0, None
+                for seg in segs:
+                    if len(seg) == 0:
+                        continue
+                    mask = (seg[:, 0] < x_max * 0.97) & (seg[:, 1] < y_max * 0.97)
+                    seg = seg[mask]
+                    if len(seg) == 0:
+                        continue
+                    idx = np.argmax(seg[:, 0])
+                    if seg[idx, 0] > best_x:
+                        best_x, best_y = seg[idx, 0], seg[idx, 1]
+                if best_y is not None:
+                    ax.text(
+                        best_x + x_max * 0.01, best_y,
+                        self.ic_label_fmt.format(level),
+                        color=self.color, fontsize=9, va="center",
+                        clip_on=True,
+                    )
 
         if self.show_rays and hasattr(self.func, "utility_type"):
             if self.func.utility_type is UtilityType.KINKED:

--- a/econ_viz/models/__init__.py
+++ b/econ_viz/models/__init__.py
@@ -9,7 +9,7 @@ and exposes ``utility_type``, ``ray_slopes``, and ``kink_points`` for
 rendering support.
 """
 
-from .core import CobbDouglas, Leontief, PerfectSubstitutes, CES, Satiation, QuasiLinear, StoneGeary
+from .core import CobbDouglas, Leontief, PerfectSubstitutes, CES, Satiation, QuasiLinear, StoneGeary, Translog
 from .advanced import CustomUtility, MultiGoodCD
 from .protocol import UtilityFunction
 
@@ -23,5 +23,6 @@ __all__ = [
     "CustomUtility",
     "MultiGoodCD",
     "StoneGeary",
+    "Translog",
     "UtilityFunction",
 ]

--- a/econ_viz/models/core.py
+++ b/econ_viz/models/core.py
@@ -11,6 +11,17 @@ protocol:
 * **ray_slopes()** — slopes for economically meaningful rays from the origin.
 * **kink_points(levels)** — coordinates of non-differentiable kink points on
   specified contour levels (non-empty only for ``KINKED`` preferences).
+
+Class order
+-----------
+1. CobbDouglas      — workhorse smooth preferences
+2. CES              — generalises Cobb-Douglas via substitution parameter
+3. PerfectSubstitutes — linear (rho=1 limit of CES)
+4. Leontief         — kinked (rho=-inf limit of CES)
+5. Translog         — flexible second-order log approximation
+6. QuasiLinear      — one linear good, no income effect
+7. StoneGeary       — subsistence extension of Cobb-Douglas
+8. Satiation        — bliss-point / non-monotone preferences
 """
 
 import numpy as np
@@ -55,37 +66,59 @@ class CobbDouglas:
 
 
 @dataclass
-class Leontief:
-    """Leontief (perfect complements) utility: U(x, y) = min(ax, by).
+class CES:
+    """Constant Elasticity of Substitution utility:
 
-    Indifference curves exhibit right-angle kinks along the ray y = (a/b)x.
-    At utility level U, the kink occurs at (U/a, U/b).
+    U(x, y) = (alpha * x^rho + beta * y^rho)^{1/rho}
+
+    The elasticity of substitution is sigma = 1/(1 - rho). Special cases:
+
+    * rho -> 0  : Cobb-Douglas
+    * rho -> -inf : Leontief
+    * rho = 1    : perfect substitutes
+
+    The equal-price expansion path has slope (alpha/beta)^{1/(1-rho)}.
 
     Parameters
     ----------
-    a : float
-        Coefficient on good *x*.
-    b : float
-        Coefficient on good *y*.
+    alpha : float
+        Share parameter for good *x*.
+    beta : float
+        Share parameter for good *y*.
+    rho : float
+        Substitution parameter. Must not equal 1 (use
+        :class:`PerfectSubstitutes` instead).
     """
 
-    a: float = 1.0
-    b: float = 1.0
+    alpha: float = 0.5
+    beta: float = 0.5
+    rho: float = 0.5
 
     @property
     def utility_type(self) -> UtilityType:
-        return UtilityType.KINKED
+        return UtilityType.SMOOTH
 
     def __call__(self, x, y):
-        return np.minimum(self.a * x, self.b * y)
+        return (self.alpha * x ** self.rho + self.beta * y ** self.rho) ** (1 / self.rho)
 
     def ray_slopes(self) -> list[float]:
-        """Return the kink-locus slope a/b."""
-        return [self.a / self.b]
+        """Return the expansion-path slope (alpha/beta)^{1/(1-rho)}.
+
+        Falls back to beta/alpha (Cobb-Douglas limit) when rho is near zero,
+        and raises ValueError when rho equals 1.
+        """
+        if abs(self.rho - 1.0) < 1e-9:
+            raise InvalidParameterError(
+                "CES with rho=1 is equivalent to perfect substitutes; "
+                "use PerfectSubstitutes instead."
+            )
+        if abs(self.rho) < 1e-9:
+            # Cobb-Douglas limit: slope = beta / alpha
+            return [self.beta / self.alpha]
+        return [(self.alpha / self.beta) ** (1 / (1 - self.rho))]
 
     def kink_points(self, levels: list[float]) -> list[tuple[float, float]]:
-        """Return kink vertices (U/a, U/b) for each contour level."""
-        return [(u / self.a, u / self.b) for u in levels]
+        return []
 
 
 @dataclass
@@ -122,53 +155,111 @@ class PerfectSubstitutes:
 
 
 @dataclass
-class Satiation:
-    """Satiation (bliss-point) utility: U(x, y) = -a(x - x*)^2 - b(y - y*)^2.
+class Leontief:
+    """Leontief (perfect complements) utility: U(x, y) = min(ax, by).
 
-    Utility rises as the bundle approaches the bliss point (x*, y*) and falls
-    away from it in all directions.  Indifference curves are closed ellipses
-    centred on the bliss point.
+    Indifference curves exhibit right-angle kinks along the ray y = (a/b)x.
+    At utility level U, the kink occurs at (U/a, U/b).
 
     Parameters
     ----------
-    bliss_x : float
-        x-coordinate of the bliss point x*.
-    bliss_y : float
-        y-coordinate of the bliss point y*.
     a : float
-        Curvature (penalty weight) along the x-axis.  Must be positive.
+        Coefficient on good *x*.
     b : float
-        Curvature (penalty weight) along the y-axis.  Must be positive.
+        Coefficient on good *y*.
     """
 
-    bliss_x: float = 5.0
-    bliss_y: float = 5.0
     a: float = 1.0
     b: float = 1.0
 
+    @property
+    def utility_type(self) -> UtilityType:
+        return UtilityType.KINKED
+
+    def __call__(self, x, y):
+        return np.minimum(self.a * x, self.b * y)
+
+    def ray_slopes(self) -> list[float]:
+        """Return the kink-locus slope a/b."""
+        return [self.a / self.b]
+
+    def kink_points(self, levels: list[float]) -> list[tuple[float, float]]:
+        """Return kink vertices (U/a, U/b) for each contour level."""
+        return [(u / self.a, u / self.b) for u in levels]
+
+
+@dataclass
+class Translog:
+    """Transcendental logarithmic utility function.
+
+    The *translog* specification is a flexible second-order approximation to
+    any smooth utility function in log-space:
+
+    .. math::
+
+        \\ln U(x, y) = \\alpha_0
+                     + \\alpha_x \\ln x + \\alpha_y \\ln y
+                     + \\tfrac{1}{2} \\beta_{xx} (\\ln x)^2
+                     + \\tfrac{1}{2} \\beta_{yy} (\\ln y)^2
+                     + \\beta_{xy} \\ln x \\cdot \\ln y
+
+    Setting ``beta_xx = beta_yy = beta_xy = 0`` recovers Cobb-Douglas.
+
+    Parameters
+    ----------
+    alpha_x : float
+        First-order coefficient on :math:`\\ln x`.
+    alpha_y : float
+        First-order coefficient on :math:`\\ln y`.
+    beta_xx : float
+        Second-order own-effect on :math:`\\ln x`.  Default 0.
+    beta_yy : float
+        Second-order own-effect on :math:`\\ln y`.  Default 0.
+    beta_xy : float
+        Cross-effect :math:`\\ln x \\cdot \\ln y`.  Default 0.
+    alpha_0 : float
+        Intercept in log-utility.  Scales the overall utility level.
+    """
+
+    alpha_x: float = 0.5
+    alpha_y: float = 0.5
+    beta_xx: float = 0.0
+    beta_yy: float = 0.0
+    beta_xy: float = 0.0
+    alpha_0: float = 0.0
+
     def __post_init__(self) -> None:
-        if self.a <= 0 or self.b <= 0:
-            raise InvalidParameterError("Satiation parameters a and b must be positive.")
+        if self.alpha_x <= 0 or self.alpha_y <= 0:
+            raise InvalidParameterError(
+                "Translog: alpha_x and alpha_y must be positive."
+            )
 
     @property
     def utility_type(self) -> UtilityType:
         return UtilityType.SMOOTH
 
     def __call__(self, x, y):
-        return -self.a * (x - self.bliss_x) ** 2 - self.b * (y - self.bliss_y) ** 2
+        lx = np.log(x)
+        ly = np.log(y)
+        ln_u = (
+            self.alpha_0
+            + self.alpha_x * lx
+            + self.alpha_y * ly
+            + 0.5 * self.beta_xx * lx ** 2
+            + 0.5 * self.beta_yy * ly ** 2
+            + self.beta_xy * lx * ly
+        )
+        return np.exp(ln_u)
 
     def ray_slopes(self) -> list[float]:
-        """Return the slope of the ray from origin through the bliss point."""
-        if self.bliss_x == 0:
-            return []
-        return [self.bliss_y / self.bliss_x]
+        return []
 
     def kink_points(self, levels: list[float]) -> list[tuple[float, float]]:
         return []
 
 
 def _validate_v_func(v_func: Callable, name: str = "v_func") -> None:
-    """Check f'(z) > 0 and f''(z) < 0 on z ∈ [0.1, 10] via central differences."""
+    """Check f'(z) > 0 and f''(z) < 0 on z in [0.1, 10] via central differences."""
     h = 1e-5
     z = np.linspace(0.1, 10.0, 100)
 
@@ -182,11 +273,11 @@ def _validate_v_func(v_func: Callable, name: str = "v_func") -> None:
 
     if np.any(fprime <= -1e-8):
         raise ValueError(
-            f"{name}: 違反邊際效用大於零的單調性假設 (f'(z) ≤ 0 detected)."
+            f"{name}: monotonicity violated -- f'(z) <= 0 detected."
         )
     if np.any(fdouble >= 1e-8):
         raise ValueError(
-            f"{name}: 違反邊際效用遞減假設 (f''(z) ≥ 0 detected)."
+            f"{name}: diminishing marginal utility violated -- f''(z) >= 0 detected."
         )
 
 
@@ -203,7 +294,7 @@ class QuasiLinear:
     ----------
     v_func : Callable
         Strictly increasing, strictly concave scalar function f(z).
-        Validated numerically on z ∈ [0.1, 10] via central differences.
+        Validated numerically on z in [0.1, 10] via central differences.
         Defaults to ``numpy.log``.
     linear_in : {'x', 'y'}
         Which good enters *linearly*.  Defaults to ``'y'``, giving
@@ -288,7 +379,7 @@ class StoneGeary:
         return float(result) if result.ndim == 0 else result
 
     def lower_bounds(self) -> tuple[float, float]:
-        """Return the minimum feasible (x, y) — the subsistence point."""
+        """Return the minimum feasible (x, y) -- the subsistence point."""
         return (self.bar_x, self.bar_y)
 
     def subsistence_lines(self) -> tuple[float, float]:
@@ -303,56 +394,46 @@ class StoneGeary:
 
 
 @dataclass
-class CES:
-    """Constant Elasticity of Substitution utility:
+class Satiation:
+    """Satiation (bliss-point) utility: U(x, y) = -a(x - x*)^2 - b(y - y*)^2.
 
-    U(x, y) = (alpha * x^rho + beta * y^rho)^{1/rho}
-
-    The elasticity of substitution is sigma = 1/(1 - rho). Special cases:
-
-    * rho -> 0  : Cobb-Douglas
-    * rho -> -inf : Leontief
-    * rho = 1    : perfect substitutes
-
-    The equal-price expansion path has slope (alpha/beta)^{1/(1-rho)}.
+    Utility rises as the bundle approaches the bliss point (x*, y*) and falls
+    away from it in all directions.  Indifference curves are closed ellipses
+    centred on the bliss point.
 
     Parameters
     ----------
-    alpha : float
-        Share parameter for good *x*.
-    beta : float
-        Share parameter for good *y*.
-    rho : float
-        Substitution parameter. Must not equal 1 (use
-        :class:`PerfectSubstitutes` instead).
+    bliss_x : float
+        x-coordinate of the bliss point x*.
+    bliss_y : float
+        y-coordinate of the bliss point y*.
+    a : float
+        Curvature (penalty weight) along the x-axis.  Must be positive.
+    b : float
+        Curvature (penalty weight) along the y-axis.  Must be positive.
     """
 
-    alpha: float = 0.5
-    beta: float = 0.5
-    rho: float = 0.5
+    bliss_x: float = 5.0
+    bliss_y: float = 5.0
+    a: float = 1.0
+    b: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.a <= 0 or self.b <= 0:
+            raise InvalidParameterError("Satiation parameters a and b must be positive.")
 
     @property
     def utility_type(self) -> UtilityType:
         return UtilityType.SMOOTH
 
     def __call__(self, x, y):
-        return (self.alpha * x ** self.rho + self.beta * y ** self.rho) ** (1 / self.rho)
+        return -self.a * (x - self.bliss_x) ** 2 - self.b * (y - self.bliss_y) ** 2
 
     def ray_slopes(self) -> list[float]:
-        """Return the expansion-path slope (alpha/beta)^{1/(1-rho)}.
-
-        Falls back to beta/alpha (Cobb-Douglas limit) when rho is near zero,
-        and raises ValueError when rho equals 1.
-        """
-        if abs(self.rho - 1.0) < 1e-9:
-            raise InvalidParameterError(
-                "CES with rho=1 is equivalent to perfect substitutes; "
-                "use PerfectSubstitutes instead."
-            )
-        if abs(self.rho) < 1e-9:
-            # Cobb-Douglas limit: slope = beta / alpha
-            return [self.beta / self.alpha]
-        return [(self.alpha / self.beta) ** (1 / (1 - self.rho))]
+        """Return the slope of the ray from origin through the bliss point."""
+        if self.bliss_x == 0:
+            return []
+        return [self.bliss_y / self.bliss_x]
 
     def kink_points(self, levels: list[float]) -> list[tuple[float, float]]:
         return []

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -277,3 +277,55 @@ class TestComponents:
     def test_draw_ray_steep_clips_to_y_max(self):
         """A slope steep enough to exceed y_max must be clipped correctly."""
         draw_ray(self.ax, slope=10.0, x_max=10, y_max=10, color="black", linewidth=0.8)
+
+
+class TestLegendAndICLabels:
+    """Tests for Canvas legend support and right-side IC labels (#11)."""
+
+    def setup_method(self):
+        self.cvs = Canvas(x_max=10, y_max=10)
+
+    def test_add_utility_with_label_registers_handle(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2, label="$U_1$")
+        assert len(self.cvs._legend_handles) == 1
+        assert self.cvs._legend_handles[0].get_label() == "$U_1$"
+
+    def test_add_utility_without_label_no_handle(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2)
+        assert len(self.cvs._legend_handles) == 0
+
+    def test_multiple_labels_accumulate(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2, label="$U_A$")
+        self.cvs.add_utility(CobbDouglas(alpha=0.3, beta=0.7), levels=2, label="$U_B$")
+        assert len(self.cvs._legend_handles) == 2
+
+    def test_show_legend_returns_canvas(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2, label="$U_1$")
+        result = self.cvs.show_legend()
+        assert result is self.cvs
+
+    def test_show_legend_creates_legend_object(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2, label="$U_1$")
+        self.cvs.show_legend()
+        assert self.cvs.ax.get_legend() is not None
+
+    def test_show_legend_no_labels_no_legend(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2)
+        self.cvs.show_legend()
+        assert self.cvs.ax.get_legend() is None
+
+    def test_show_ic_labels_does_not_raise(self):
+        """IC labels must render without error."""
+        self.cvs.add_utility(CobbDouglas(), levels=3, show_ic_labels=True)
+
+    def test_show_ic_labels_custom_fmt(self):
+        self.cvs.add_utility(CobbDouglas(), levels=2, show_ic_labels=True,
+                              ic_label_fmt="{:.3f}")
+
+    def test_chaining_with_legend(self):
+        result = (
+            self.cvs
+            .add_utility(CobbDouglas(), levels=2, label="$U_1$")
+            .show_legend()
+        )
+        assert result is self.cvs

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,7 @@ from econ_viz.models import (
     Satiation,
     QuasiLinear,
     StoneGeary,
+    Translog,
 )
 
 
@@ -278,15 +279,76 @@ class TestQuasiLinear:
 
     def test_convex_v_func_raises(self):
         """z**2 has f'' > 0 — must be rejected as non-concave."""
-        with pytest.raises(ValueError, match="遞減"):
+        with pytest.raises(ValueError, match="diminishing marginal utility violated"):
             QuasiLinear(v_func=lambda z: z ** 2)
 
     def test_decreasing_v_func_raises(self):
         """A decreasing function violates the monotonicity assumption."""
-        with pytest.raises(ValueError, match="單調性"):
+        with pytest.raises(ValueError, match="monotonicity violated"):
             QuasiLinear(v_func=lambda z: -z)
 
     def test_custom_concave_func(self):
         """sqrt is valid: f' > 0 and f'' < 0 everywhere."""
         ql = QuasiLinear(v_func=np.sqrt)
         assert ql(4.0, 1.0) == pytest.approx(3.0)
+
+
+class TestTranslog:
+    """Unit tests for the Translog utility model."""
+
+    def test_reduces_to_cobb_douglas(self):
+        """With all beta=0 and alpha_0=0, Translog = x^alpha_x * y^alpha_y."""
+        tl = Translog(alpha_x=0.4, alpha_y=0.6)
+        cd = CobbDouglas(alpha=0.4, beta=0.6)
+        assert tl(3.0, 5.0) == pytest.approx(cd(3.0, 5.0), rel=1e-6)
+
+    def test_scalar_positive(self):
+        tl = Translog(alpha_x=0.5, alpha_y=0.5)
+        assert tl(2.0, 3.0) > 0
+
+    def test_array_input(self):
+        tl = Translog(alpha_x=0.5, alpha_y=0.5)
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1.0, 2.0, 3.0])
+        result = tl(x, y)
+        assert result.shape == (3,)
+        assert np.all(result > 0)
+
+    def test_alpha_0_scales_utility(self):
+        """alpha_0 > 0 multiplies utility by exp(alpha_0)."""
+        tl0 = Translog(alpha_x=0.5, alpha_y=0.5, alpha_0=0.0)
+        tl1 = Translog(alpha_x=0.5, alpha_y=0.5, alpha_0=1.0)
+        assert tl1(2.0, 3.0) == pytest.approx(tl0(2.0, 3.0) * np.e, rel=1e-6)
+
+    def test_beta_xx_increases_curvature(self):
+        """Positive beta_xx increases utility when ln(x) > 0 (x > 1)."""
+        tl_flat = Translog(alpha_x=0.5, alpha_y=0.5, beta_xx=0.0)
+        tl_curved = Translog(alpha_x=0.5, alpha_y=0.5, beta_xx=0.2)
+        # At x=3 > 1: ln(3)>0, so positive beta_xx increases utility
+        assert tl_curved(3.0, 2.0) > tl_flat(3.0, 2.0)
+
+    def test_utility_type_smooth(self):
+        assert Translog().utility_type is UtilityType.SMOOTH
+
+    def test_ray_slopes_empty(self):
+        assert Translog().ray_slopes() == []
+
+    def test_kink_points_empty(self):
+        assert Translog().kink_points([1.0, 2.0]) == []
+
+    def test_invalid_alpha_x(self):
+        with pytest.raises(InvalidParameterError):
+            Translog(alpha_x=0.0, alpha_y=0.5)
+
+    def test_invalid_alpha_y(self):
+        with pytest.raises(InvalidParameterError):
+            Translog(alpha_x=0.5, alpha_y=-0.1)
+
+    def test_defaults(self):
+        tl = Translog()
+        assert tl.alpha_x == 0.5
+        assert tl.alpha_y == 0.5
+        assert tl.beta_xx == 0.0
+        assert tl.beta_yy == 0.0
+        assert tl.beta_xy == 0.0
+        assert tl.alpha_0 == 0.0


### PR DESCRIPTION
## Summary

- **#9 Translog**: New `Translog` utility class — second-order transcendental logarithmic specification in log-space. Reduces to Cobb-Douglas when all beta params are zero. Validated `alpha_x, alpha_y > 0`.
- **#11 Legend + IC labels**: `add_utility()` now accepts `label`, `show_ic_labels`, and `ic_label_fmt`; new `show_legend()` method on `Canvas` collects proxy artists and renders a matplotlib legend.
- **Housekeeping**: reordered `core.py` classes from most standard to most specialised (CobbDouglas → CES → PerfectSubstitutes → Leontief → Translog → QuasiLinear → StoneGeary → Satiation); replaced Chinese error messages in `_validate_v_func` with English.

## Test plan

- [ ] 255 tests pass (`pytest -q`)
- [ ] `TestTranslog` — 12 cases covering scalar/array eval, alpha_0 scaling, beta curvature, utility_type, validation, defaults
- [ ] `TestLegendAndICLabels` — 9 cases covering handle registration, `show_legend()`, IC label rendering, method chaining