### PR TITLE
feat: comparative statics helper (closes #12)

### DIFF
--- a/econ_viz/optimizer/__init__.py
+++ b/econ_viz/optimizer/__init__.py
@@ -8,5 +8,6 @@ that the :class:`~econ_viz.canvas.base.Canvas` can render directly.
 """
 
 from .solver import Equilibrium, solve
+from .statics import ComparativeStatics, comparative_statics
 
-__all__ = ["Equilibrium", "solve"]
+__all__ = ["Equilibrium", "solve", "ComparativeStatics", "comparative_statics"]

--- a/econ_viz/optimizer/statics.py
+++ b/econ_viz/optimizer/statics.py
@@ -1,0 +1,181 @@
+"""
+Comparative statics for consumer demand.
+
+:func:`comparative_statics` numerically computes the six partial derivatives
+of the Marshallian demands with respect to prices and income by applying
+central finite differences to :func:`~econ_viz.optimizer.solver.solve`.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+from .solver import solve
+from ..exceptions import InvalidParameterError
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_H = 1e-3
+
+
+@dataclass(frozen=True)
+class ComparativeStatics:
+    """Partial derivatives of Marshallian demands.
+
+    Attributes
+    ----------
+    dx_dpx : float  ∂x*/∂p_x
+    dx_dpy : float  ∂x*/∂p_y
+    dx_dI  : float  ∂x*/∂I  (Engel slope for x)
+    dy_dpx : float  ∂y*/∂p_x
+    dy_dpy : float  ∂y*/∂p_y
+    dy_dI  : float  ∂y*/∂I  (Engel slope for y)
+    """
+
+    dx_dpx: float
+    dx_dpy: float
+    dx_dI: float
+    dy_dpx: float
+    dy_dpy: float
+    dy_dI: float
+
+    def __repr__(self) -> str:  # pragma: no cover
+        rows = [
+            ("∂x*/∂pₓ", self.dx_dpx),
+            ("∂x*/∂pᵧ", self.dx_dpy),
+            ("∂x*/∂I ", self.dx_dI),
+            ("∂y*/∂pₓ", self.dy_dpx),
+            ("∂y*/∂pᵧ", self.dy_dpy),
+            ("∂y*/∂I ", self.dy_dI),
+        ]
+        lines = ["ComparativeStatics"]
+        lines.append("─" * 26)
+        for label, val in rows:
+            lines.append(f"  {label}  {val:+.6f}")
+        lines.append("─" * 26)
+        return "\n".join(lines)
+
+
+def comparative_statics(
+    func,
+    px: float,
+    py: float,
+    income: float,
+    h: float = _DEFAULT_H,
+) -> ComparativeStatics:
+    """Compute comparative statics for a consumer optimisation problem.
+
+    Uses central finite differences to estimate all six partial derivatives
+    of the Marshallian demands with respect to prices and income.
+
+    Step sizes are *relative*: for each parameter ``p`` the perturbation is
+    ``max(h * p, h)`` so that the step is never degenerate when the parameter
+    value is close to zero.
+
+    Parameters
+    ----------
+    func : UtilityFunction
+        A utility model conforming to the protocol.
+    px : float
+        Price of good *x*. Must be positive.
+    py : float
+        Price of good *y*. Must be positive.
+    income : float
+        Total budget. Must be positive.
+    h : float
+        Relative step size for finite differences. The actual perturbation for
+        parameter *p* is ``max(h * p, h)``, so it scales with the parameter
+        value.  Default ``1e-3`` — large enough to dominate SLSQP variable
+        noise while keeping the central-difference truncation error O(h²).
+
+    Returns
+    -------
+    ComparativeStatics
+
+    Raises
+    ------
+    InvalidParameterError
+        If prices or income are non-positive.
+
+    Warns
+    -----
+    UserWarning
+        If sign consistency checks fail (e.g. ∂x*/∂p_x > 0, ∂x*/∂I < 0).
+    """
+    if px <= 0 or py <= 0 or income <= 0:
+        raise InvalidParameterError(
+            f"Prices and income must be positive (px={px}, py={py}, income={income})."
+        )
+
+    def _deriv(param: str) -> tuple[float, float]:
+        """Return (dx/dparam, dy/dparam) via central differences."""
+        base = {"px": px, "py": py, "income": income}
+        val = base[param]
+        step = max(h * val, h)
+
+        lo = {**base, param: val - step}
+        hi = {**base, param: val + step}
+
+        eq_lo = solve(func, **lo)
+        eq_hi = solve(func, **hi)
+
+        dx = (eq_hi.x - eq_lo.x) / (2 * step)
+        dy = (eq_hi.y - eq_lo.y) / (2 * step)
+        return dx, dy
+
+    dx_dpx, dy_dpx = _deriv("px")
+    dx_dpy, dy_dpy = _deriv("py")
+    dx_dI,  dy_dI  = _deriv("income")
+
+    logger.debug(
+        "ComparativeStatics at (px=%.4g, py=%.4g, I=%.4g): "
+        "dx/dpx=%.4g  dx/dpy=%.4g  dx/dI=%.4g  "
+        "dy/dpx=%.4g  dy/dpy=%.4g  dy/dI=%.4g",
+        px, py, income,
+        dx_dpx, dx_dpy, dx_dI,
+        dy_dpx, dy_dpy, dy_dI,
+    )
+
+    cs = ComparativeStatics(
+        dx_dpx=dx_dpx,
+        dx_dpy=dx_dpy,
+        dx_dI=dx_dI,
+        dy_dpx=dy_dpx,
+        dy_dpy=dy_dpy,
+        dy_dI=dy_dI,
+    )
+
+    _warn_sign_violations(cs)
+    return cs
+
+
+def _warn_sign_violations(cs: ComparativeStatics) -> None:
+    """Emit UserWarnings for economically unusual sign patterns."""
+    _tol = 1e-8
+
+    if cs.dx_dpx > _tol:
+        warnings.warn(
+            f"∂x*/∂pₓ = {cs.dx_dpx:.4g} > 0 — Giffen good or numerical artefact.",
+            UserWarning,
+            stacklevel=3,
+        )
+    if cs.dy_dpy > _tol:
+        warnings.warn(
+            f"∂y*/∂pᵧ = {cs.dy_dpy:.4g} > 0 — Giffen good or numerical artefact.",
+            UserWarning,
+            stacklevel=3,
+        )
+    if cs.dx_dI < -_tol:
+        warnings.warn(
+            f"∂x*/∂I = {cs.dx_dI:.4g} < 0 — inferior good for x.",
+            UserWarning,
+            stacklevel=3,
+        )
+    if cs.dy_dI < -_tol:
+        warnings.warn(
+            f"∂y*/∂I = {cs.dy_dI:.4g} < 0 — inferior good for y.",
+            UserWarning,
+            stacklevel=3,
+        )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -5,7 +5,7 @@ import pytest
 
 from econ_viz.exceptions import InvalidParameterError, OptimizationError
 from econ_viz.models import CobbDouglas, Leontief, PerfectSubstitutes, CES, QuasiLinear, StoneGeary
-from econ_viz.optimizer import Equilibrium, solve
+from econ_viz.optimizer import Equilibrium, solve, ComparativeStatics, comparative_statics
 
 
 def _on_budget(eq: Equilibrium, px, py, income, rtol=1e-4):
@@ -347,3 +347,162 @@ class TestSolvePerfectSubstitutesAnalytic:
         else:
             assert eq.x == pytest.approx(0.0, abs=1e-9)
             assert eq.y == pytest.approx(income / py, rel=1e-4)
+
+
+class TestComparativeStaticsCobbDouglas:
+    """Verify numerical derivatives against Cobb-Douglas closed-form expressions.
+
+    Analytic Marshallian demands for CD(α, β) with α+β normalised:
+        x* = α/(α+β) · I/pₓ
+        y* = β/(α+β) · I/pᵧ
+
+    Partial derivatives:
+        ∂x*/∂pₓ = -α/(α+β) · I/pₓ²    ∂x*/∂pᵧ = 0       ∂x*/∂I = α/(α+β)/pₓ
+        ∂y*/∂pₓ = 0                    ∂y*/∂pᵧ = -β/(α+β)·I/pᵧ²  ∂y*/∂I = β/(α+β)/pᵧ
+    """
+
+    def setup_method(self):
+        self.alpha, self.beta = 0.4, 0.6
+        self.model = CobbDouglas(alpha=self.alpha, beta=self.beta)
+        self.px, self.py, self.income = 2.0, 3.0, 60.0
+        self.cs = comparative_statics(self.model, self.px, self.py, self.income)
+        s = self.alpha + self.beta
+        self._dx_dpx = -(self.alpha / s) * self.income / self.px ** 2
+        self._dx_dpy = 0.0
+        self._dx_dI  = (self.alpha / s) / self.px
+        self._dy_dpx = 0.0
+        self._dy_dpy = -(self.beta  / s) * self.income / self.py ** 2
+        self._dy_dI  = (self.beta  / s) / self.py
+
+    def test_dx_dpx(self):
+        assert self.cs.dx_dpx == pytest.approx(self._dx_dpx, rel=2e-2)
+
+    def test_dx_dpy(self):
+        assert self.cs.dx_dpy == pytest.approx(self._dx_dpy, abs=1e-3)
+
+    def test_dx_dI(self):
+        assert self.cs.dx_dI == pytest.approx(self._dx_dI, rel=2e-2)
+
+    def test_dy_dpx(self):
+        assert self.cs.dy_dpx == pytest.approx(self._dy_dpx, abs=1e-3)
+
+    def test_dy_dpy(self):
+        assert self.cs.dy_dpy == pytest.approx(self._dy_dpy, rel=2e-2)
+
+    def test_dy_dI(self):
+        assert self.cs.dy_dI == pytest.approx(self._dy_dI, rel=2e-2)
+
+    def test_returns_comparative_statics_instance(self):
+        assert isinstance(self.cs, ComparativeStatics)
+
+    def test_frozen(self):
+        with pytest.raises(Exception):
+            self.cs.dx_dpx = 0.0
+
+
+class TestComparativeStaticsPerfectSubstitutes:
+    """Corner-solution comparative statics for perfect substitutes.
+
+    With a=3, b=1, pₓ=1, pᵧ=3 the consumer spends everything on x:
+        x* = I/pₓ  →  ∂x*/∂pₓ = -I/pₓ², ∂x*/∂pᵧ = 0, ∂x*/∂I = 1/pₓ
+        y* = 0      →  all y-derivatives ≈ 0
+    """
+
+    def setup_method(self):
+        self.model = PerfectSubstitutes(a=3.0, b=1.0)
+        self.px, self.py, self.income = 1.0, 3.0, 9.0
+        self.cs = comparative_statics(self.model, self.px, self.py, self.income)
+
+    def test_dx_dpx_negative(self):
+        expected = -self.income / self.px ** 2
+        assert self.cs.dx_dpx == pytest.approx(expected, rel=1e-3)
+
+    def test_dx_dI_positive(self):
+        expected = 1.0 / self.px
+        assert self.cs.dx_dI == pytest.approx(expected, rel=1e-3)
+
+    def test_dy_dI_near_zero(self):
+        assert abs(self.cs.dy_dI) < 1e-4
+
+
+class TestComparativeStaticsLeontief:
+    """Leontief comparative statics via the analytic kink-solution path.
+
+    Marshallian demands:  x* = I/(pₓ + a/b·pᵧ),  y* = a/b·x*
+
+    With a=b=1: x* = I/(pₓ+pᵧ), y* = I/(pₓ+pᵧ)
+        ∂x*/∂pₓ = -I/(pₓ+pᵧ)²
+        ∂x*/∂I  =  1/(pₓ+pᵧ)
+    """
+
+    def setup_method(self):
+        self.model = Leontief(a=1.0, b=1.0)
+        self.px, self.py, self.income = 2.0, 3.0, 30.0
+        self.cs = comparative_statics(self.model, self.px, self.py, self.income)
+        denom = self.px + self.py
+        self._dx_dpx = -self.income / denom ** 2
+        self._dx_dI  =  1.0 / denom
+
+    def test_dx_dpx(self):
+        assert self.cs.dx_dpx == pytest.approx(self._dx_dpx, rel=2e-2)
+
+    def test_dx_dI(self):
+        assert self.cs.dx_dI == pytest.approx(self._dx_dI, rel=2e-2)
+
+
+class TestComparativeStaticsInvalidParams:
+    """Parameter validation in comparative_statics()."""
+
+    def test_zero_px(self):
+        with pytest.raises(InvalidParameterError):
+            comparative_statics(CobbDouglas(), px=0.0, py=1.0, income=10.0)
+
+    def test_negative_py(self):
+        with pytest.raises(InvalidParameterError):
+            comparative_statics(CobbDouglas(), px=1.0, py=-1.0, income=10.0)
+
+    def test_zero_income(self):
+        with pytest.raises(InvalidParameterError):
+            comparative_statics(CobbDouglas(), px=1.0, py=1.0, income=0.0)
+
+
+class TestComparativeStaticsSignWarnings:
+    """UserWarning is emitted for economically anomalous signs."""
+
+    def test_giffen_good_warns(self):
+        """A model with upward-sloping demand must trigger a UserWarning."""
+        class GiffenX:
+            """Toy model where x* rises with pₓ (pathological)."""
+            from econ_viz.enums import UtilityType as _UT
+            utility_type = _UT.SMOOTH
+
+            def __call__(self, x, y):
+                # x demand = pₓ*I so derivative is positive — purely for testing
+                return float(x * y)
+
+            def ray_slopes(self):
+                return []
+
+            def kink_points(self, levels):
+                return []
+
+            def lower_bounds(self):
+                return (0.0, 0.0)
+
+        # Patch solve to return a Giffen-like pattern
+        import econ_viz.optimizer.statics as statics_mod
+        original_solve = statics_mod.solve
+
+        call_count = [0]
+
+        def fake_solve(func, px, py, income):
+            call_count[0] += 1
+            # Make x* increase with pₓ by returning x = pₓ * 2
+            return Equilibrium(x=px * 2, y=1.0, utility=1.0, bundle_type="interior")
+
+        statics_mod.solve = fake_solve
+        try:
+            with pytest.warns(UserWarning, match="Giffen"):
+                comparative_statics(GiffenX(), px=2.0, py=1.0, income=10.0)
+        finally:
+            statics_mod.solve = original_solve


### PR DESCRIPTION
## Summary

- Adds `ComparativeStatics` frozen dataclass with six partial-derivative fields (`dx_dpx`, `dx_dpy`, `dx_dI`, `dy_dpx`, `dy_dpy`, `dy_dI`) and a formatted `__repr__` table
- Adds `comparative_statics(func, px, py, income, h=1e-3)` — estimates Marshallian demand derivatives via central finite differences; works with all existing utility models (smooth, kinked, corner)
- Emits `UserWarning` for Giffen goods (`∂x*/∂pₓ > 0`) or inferior goods (`∂x*/∂I < 0`)
- Exports both symbols from `econ_viz.optimizer`

## Notes

Default step size is `h=1e-3` (relative) rather than the `1e-5` mentioned in the issue. The smaller step is below SLSQP's variable noise floor, which would corrupt the finite differences; `1e-3` keeps truncation error at O(h²) ≈ O(1e-6) while staying well above solver noise.

## Test plan

- [ ] `TestComparativeStaticsCobbDouglas` — six derivatives checked against closed-form analytic values
- [ ] `TestComparativeStaticsPerfectSubstitutes` — corner-solution path
- [ ] `TestComparativeStaticsLeontief` — analytic kink-solution path
- [ ] `TestComparativeStaticsInvalidParams` — parameter validation
- [ ] `TestComparativeStaticsSignWarnings` — Giffen-good warning via monkeypatch