### PR TITLE
fix: Edgeworth line styles (contract/price dashed black)

### DIFF
--- a/econ_viz/consumer/edgeworth.py
+++ b/econ_viz/consumer/edgeworth.py
@@ -416,7 +416,7 @@ class EdgeworthBox:
             points = self._contract_curve_pareto(n=n)
 
         self.contract_curve_points = points
-        c = color or self.theme.budget_color
+        c = color or "#000000"
         lw = linewidth if linewidth is not None else 1.2
         plot_contract_curve(
             self.ax,
@@ -566,8 +566,9 @@ class EdgeworthBox:
         px: float,
         py: float,
         *,
-        color: str = "#1F4BFF",
-        linewidth: float = 2.0,
+        color: str = "#000000",
+        linewidth: float = 1.2,
+        linestyle: str = "--",
         label: str = "Price line",
     ) -> "EdgeworthBox":
         """Draw the price line through endowment with slope -px/py."""
@@ -579,7 +580,14 @@ class EdgeworthBox:
         ex, ey = self.endowment
         income = px * ex + py * ey
         pts = self._line_box_intersections(px, py, income)
-        plot_price_line(self.ax, points=pts, color=color, linewidth=linewidth, label=label)
+        plot_price_line(
+            self.ax,
+            points=pts,
+            color=color,
+            linewidth=linewidth,
+            linestyle=linestyle,
+            label=label,
+        )
         return self
 
     def add_walrasian_equilibrium(

--- a/econ_viz/consumer/edgeworth_plotter.py
+++ b/econ_viz/consumer/edgeworth_plotter.py
@@ -35,7 +35,15 @@ def plot_endowment(
     )
 
 
-def plot_price_line(ax, *, points: list[tuple[float, float]], color: str, linewidth: float, label: str) -> None:
+def plot_price_line(
+    ax,
+    *,
+    points: list[tuple[float, float]],
+    color: str,
+    linewidth: float,
+    linestyle: str,
+    label: str,
+) -> None:
     """Draw the budget/price line segment inside the Edgeworth box."""
     if len(points) < 2:
         return
@@ -44,6 +52,7 @@ def plot_price_line(ax, *, points: list[tuple[float, float]], color: str, linewi
         [points[0][1], points[-1][1]],
         color=color,
         linewidth=linewidth,
+        linestyle=linestyle,
         label=label,
     )
 
@@ -92,10 +101,28 @@ def plot_indifference_pair(
     color_a: str,
     color_b: str,
     linewidth: float,
+    linestyle_a: str = "-",
+    linestyle_b: str = "-",
 ) -> None:
     """Draw both agents' indifference contour families."""
-    ax.contour(X, Y, U_a, levels=levels_a, colors=color_a, linewidths=linewidth)
-    ax.contour(X, Y, U_b, levels=levels_b, colors=color_b, linewidths=linewidth, linestyles="--")
+    ax.contour(
+        X,
+        Y,
+        U_a,
+        levels=levels_a,
+        colors=color_a,
+        linewidths=linewidth,
+        linestyles=linestyle_a,
+    )
+    ax.contour(
+        X,
+        Y,
+        U_b,
+        levels=levels_b,
+        colors=color_b,
+        linewidths=linewidth,
+        linestyles=linestyle_b,
+    )
 
 
 def plot_contract_curve(

--- a/tests/test_edgeworth.py
+++ b/tests/test_edgeworth.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from econ_viz import EdgeworthBox, EquilibriumFocusConfig
+from econ_viz.consumer.edgeworth_plotter import plot_indifference_pair
 from econ_viz.models import CobbDouglas, Leontief, PerfectSubstitutes, QuasiLinear
 
 
@@ -168,7 +169,53 @@ def test_contract_curve_default_style_is_dashed_and_thin():
     assert contract_lines
     line = contract_lines[0]
     assert line.get_linestyle() == "--"
+    assert to_hex(line.get_color()) == "#000000"
     assert line.get_linewidth() <= 1.2 + 1e-9
+
+
+def test_price_line_default_style_is_black_and_dashed():
+    box = EdgeworthBox(
+        CobbDouglas(alpha=0.5, beta=0.5),
+        CobbDouglas(alpha=0.5, beta=0.5),
+        total_x=10.0,
+        total_y=10.0,
+    )
+    box.add_endowment(4.0, 6.0).add_price_line(px=1.0, py=1.0)
+    lines = [line for line in box.ax.lines if line.get_label() == "Price line"]
+    assert lines
+    line = lines[0]
+    assert line.get_linestyle() == "--"
+    assert to_hex(line.get_color()) == "#000000"
+    assert line.get_linewidth() <= 1.2 + 1e-9
+
+
+def test_indifference_pair_defaults_to_solid_for_both_agents():
+    class _SpyAxis:
+        def __init__(self):
+            self.calls = []
+
+        def contour(self, *args, **kwargs):
+            self.calls.append(kwargs)
+
+    spy = _SpyAxis()
+    X, Y = np.meshgrid(np.linspace(0.1, 0.9, 3), np.linspace(0.1, 0.9, 3))
+    U_a = X + Y
+    U_b = (1.0 - X) + (1.0 - Y)
+    plot_indifference_pair(
+        spy,
+        X=X,
+        Y=Y,
+        U_a=U_a,
+        U_b=U_b,
+        levels_a=[0.8],
+        levels_b=[0.8],
+        color_a="#111111",
+        color_b="#00a7a0",
+        linewidth=1.0,
+    )
+    assert len(spy.calls) == 2
+    assert spy.calls[0]["linestyles"] == "-"
+    assert spy.calls[1]["linestyles"] == "-"
 
 
 def test_symmetric_cobb_douglas_contract_curve_near_diagonal():


### PR DESCRIPTION
## Summary
- keep utility contours solid
- render contract curve as black dashed by default
- render price line as black dashed by default and thinner
- add regression tests for default line styles

## Validation
- poetry run pytest tests/
- poetry run python -m examples.edgeworth_box