### PR TITLE
chore(release): prepare v1.3.2 PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "econ-viz"
-version = "1.3.1"
+version = "1.3.2"
 description = "A Python toolkit for producing publication-quality microeconomics diagrams."
 readme = "README.md"
 authors = [{ name = "Anthony Sung", email = "sungpinyue@gmail.com" }]


### PR DESCRIPTION
## Summary
- bump version to 1.3.2 in pyproject.toml
- set PyPI publish action to skip existing files

## Why
- previous v1.3.1 publish failed with HTTP 400 due to existing files on PyPI
- this makes reruns safe and publishes next patch version